### PR TITLE
Include pyprojet.toml in source package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,7 +6,7 @@ recursive-include skcriteria *.py
 recursive-include skcriteria *.json
 
 exclude tox.ini
-exclude pyproject.toml
+include pyproject.toml
 exclude requirements_dev.txt
 exclude .header-template
 exclude .readthedocs.yml


### PR DESCRIPTION
This is needed to install the package from pip and the source package. I got the error on the feedstock repo at https://github.com/conda-forge/scikit-criteria-feedstock/pull/5#issuecomment-1291566107